### PR TITLE
Fixed test error on Redmine >= 4.1 env

### DIFF
--- a/test/integration/impersonation_test.rb
+++ b/test/integration/impersonation_test.rb
@@ -55,7 +55,7 @@ class ImpersonationTest < ActionDispatch::IntegrationTest
 
     post '/admin/impersonation', params: {user_id: user.id}
     follow_redirect!
-    assert_equal User.current, user
+    assert_equal user, User.find(session[:user_id])
     assert_select '#impersonation-bar'
   end
 
@@ -66,7 +66,7 @@ class ImpersonationTest < ActionDispatch::IntegrationTest
 
     post '/admin/impersonation', params: {user_id: user.id}
     assert_response 403
-    assert_equal User.current.login, 'jsmith'
+    assert_equal 'jsmith', User.find(session[:user_id]).login
   end
 
   test "impersonating user as anonymous" do


### PR DESCRIPTION
See the following redmine.org issue.  
https://www.redmine.org/issues/36336

I also fixed `assert_equal` arguments order properly (`expected`, `actual`).
https://apidock.com/ruby/MiniTest/Assertions/assert_equal

@gtt-project/maintainer
